### PR TITLE
Support for SQL single-line comments

### DIFF
--- a/languagedata.cpp
+++ b/languagedata.cpp
@@ -4242,6 +4242,7 @@ void loadMakeData(QMultiHash<char, QLatin1String> &types, QMultiHash<char, QLati
 
 void loadAsmData(QMultiHash<char, QLatin1String>& types, QMultiHash<char, QLatin1String>& keywords, QMultiHash<char, QLatin1String>& builtin, QMultiHash<char, QLatin1String>& literals, QMultiHash<char, QLatin1String>& other)
 {
+    Q_UNUSED(literals);
     types = {
         { 'i', QLatin1String("ip") },
         { 'e', QLatin1String("eip") },

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -48,7 +48,7 @@ MainWindow::MainWindow(QWidget *parent)
     highlighter = new QSourceHighliter(ui->plainTextEdit->document());
 
     connect(ui->langComboBox,
-            static_cast<void (QComboBox::*) (const QString&)>(&QComboBox::currentIndexChanged),
+            static_cast<void (QComboBox::*) (const QString&)>(&QComboBox::currentTextChanged),
             this, &MainWindow::languageChanged);
     connect(ui->themeComboBox,
             static_cast<void (QComboBox::*) (int)>(&QComboBox::currentIndexChanged),

--- a/qsourcehighliter.cpp
+++ b/qsourcehighliter.cpp
@@ -251,7 +251,7 @@ void QSourceHighliter::highlightSyntax(const QString &text)
                 // we have a word match check
                 // 1. if we are at the end
                 // 2. if we have a complete word
-                if (word == text.midRef(i, word.size()) &&
+                if (word == strMidRef(text, i, word.size()) &&
                     (i + word.size() == text.length() ||
                      (!text.at(i + word.size()).isLetterOrNumber() &&
                       text.at(i + word.size()) != QLatin1Char('_')))) {
@@ -366,7 +366,7 @@ void QSourceHighliter::highlightSyntax(const QString &text)
         if (( i == 0 || !text.at(i-1).isLetter()) && others.contains(text[i].toLatin1())) {
             const QList<QLatin1String> wordList = others.values(text[i].toLatin1());
             for(const QLatin1String &word : wordList) {
-                if (word == text.midRef(i, word.size()) // we have a word match
+                if (word == strMidRef(text, i, word.size()) // we have a word match
                         &&
                         (i + word.size() == text.length() // check if we are at the end
                          ||
@@ -679,8 +679,8 @@ void QSourceHighliter::ymlHighlighter(const QString &text) {
 
         //underlined links
         if (text.at(i) == QLatin1Char('h')) {
-            if (text.midRef(i, 5) == QLatin1String("https") ||
-                    text.midRef(i, 4) == QLatin1String("http")) {
+            if (strMidRef(text, i, 5) == QLatin1String("https") ||
+                    strMidRef(text, i, 4) == QLatin1String("http")) {
                 int space = text.indexOf(QChar(' '), i);
                 if (space == -1) space = textLen;
                 QTextCharFormat f = _formats[CodeString];
@@ -710,7 +710,7 @@ void QSourceHighliter::cssHighlighter(const QString &text)
             setFormat(i, space - i, _formats[CodeKeyWord]);
             i = space;
         } else if (text[i] == QLatin1Char('c')) {
-            if (text.midRef(i, 5) == QLatin1String("color")) {
+            if (strMidRef(text, i, 5) == QLatin1String("color")) {
                 i += 5;
                 int colon = text.indexOf(QLatin1Char(':'), i);
                 if (colon < 0) continue;
@@ -731,9 +731,9 @@ void QSourceHighliter::cssHighlighter(const QString &text)
                     int gPos = text.indexOf(QLatin1Char(','), rPos+1);
                     int bPos = text.indexOf(QLatin1Char(')'), gPos);
                     if (rPos > -1 && gPos > -1 && bPos > -1) {
-                        const QStringRef r = text.midRef(t+1, rPos - (t+1));
-                        const QStringRef g = text.midRef(rPos+1, gPos - (rPos + 1));
-                        const QStringRef b = text.midRef(gPos+1, bPos - (gPos+1));
+                        const auto r = strMidRef(text, t+1, rPos - (t+1));
+                        const auto g = strMidRef(text, rPos+1, gPos - (rPos + 1));
+                        const auto b = strMidRef(text, gPos+1, bPos - (gPos+1));
                         c.setRgb(r.toInt(), g.toInt(), b.toInt());
                     } else {
                         c = _formats[CodeBlock].background().color();

--- a/qsourcehighliter.cpp
+++ b/qsourcehighliter.cpp
@@ -126,6 +126,7 @@ void QSourceHighliter::highlightSyntax(const QString &text)
     bool isYAML = false;
     bool isMake = false;
     bool isAsm = false;
+    bool isSQL = false;
 
     LanguageData keywords{},
                 others{},
@@ -187,6 +188,7 @@ void QSourceHighliter::highlightSyntax(const QString &text)
             loadVData(types, keywords, builtin, literals, others);
             break;
         case CodeSQL :
+            isSQL = true;
             loadSQLData(types, keywords, builtin, literals, others);
             break;
         case CodeJSON :
@@ -312,6 +314,13 @@ void QSourceHighliter::highlightSyntax(const QString &text)
                             i = next;
                             if (i >= textLen) return;
                         }
+                    }
+                }
+            } else if (isSQL && comment.isNull() && text[i] == QLatin1Char('-')) {
+                if((i+1) < textLen){
+                    if(text[i+1] == QLatin1Char('-')) {
+                        setFormat(i, textLen, formatComment);
+                        return;
                     }
                 }
             } else if (text[i] == comment) {

--- a/qsourcehighliter.h
+++ b/qsourcehighliter.h
@@ -26,6 +26,10 @@
 
 #include <QSyntaxHighlighter>
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QStringView>
+#endif
+
 namespace QSourceHighlite {
 
 class QSourceHighliter : public QSyntaxHighlighter
@@ -145,6 +149,18 @@ private:
     void highlightInlineAsmLabels(const QString& text);
     void asmHighlighter(const QString& text);
     void initFormats();
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    static inline QStringView strMidRef(const QString& str, qsizetype position, qsizetype n = -1)
+    {
+        return QStringView(str).mid(position, n);
+    }
+#else
+    static inline QStringRef strMidRef(const QString& str, int position, int n = -1)
+    {
+        return str.midRef(position, n);
+    }
+#endif
 
     QHash<Token, QTextCharFormat> _formats;
     Language _language;

--- a/qsourcehighliterthemes.cpp
+++ b/qsourcehighliterthemes.cpp
@@ -64,6 +64,8 @@ QHash<QSourceHighliter::Token, QTextCharFormat>
     switch (theme) {
     case QSourceHighliter::Themes::Monokai:
         return monokai();
+    default:
+        return {};
     }
 }
 


### PR DESCRIPTION
This adds some support for SQL single-line comments like the following:

```sql
SELECT * FROM test; -- Select some data
```

Full disclosure: I didn't really read the source code properly, so I don't know if these changes break something. I just adapted the code for C-style single-line comments. But it seems to work fine for me.